### PR TITLE
added dropdown with link to older version of bus finder. 

### DIFF
--- a/css/busfinder.css
+++ b/css/busfinder.css
@@ -302,3 +302,29 @@ Loading Message
 	margin: 0 auto;
 	margin-bottom: 5px;
 }
+
+/************************
+Link to map version.
+************************/
+
+#old-map {
+	background-color: #DB5051;
+	height: 36px;
+	display: none;
+}
+
+#old-map p {
+	line-height: 36px;
+	text-align: center;
+	color: white;
+}
+
+#old-map p:after {
+	content: ">>";
+}
+
+#old-map a {
+	color: white !important;
+	font-style: italic;
+	font-weight: bold;
+}

--- a/css/busfinder.css
+++ b/css/busfinder.css
@@ -287,20 +287,43 @@ Loading Message
 	z-index: -5;
 	display: block;
 	position: absolute;
-	top: 45%;
+	top: 22%;
 	width: 100%;
 }
 
 #loading p {
 	text-align: center;
 	display: block;
-
+	font-size: 1.25em;
+	margin: 1em;
 }
 
 #loading img {
 	display: block;
 	margin: 0 auto;
 	margin-bottom: 5px;
+}
+
+/************************
+Attribution 
+************************/
+
+div#attribution {
+	width: 80%;
+	margin: 0 auto;
+	margin-top: 2em;
+}
+
+div#attribution p {
+	margin-bottom: 1em;
+	font-size: 90%;
+	line-height: 1.25em;
+	text-align: justify;	
+}
+
+div#attribution a {
+	font-weight: bold;
+	color: #DB5051;
 }
 
 /************************

--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
 			</div>
 		</div>
 		<div id="old-map">
-			<a href="http://map.hrtb.us/busfinder/"><p>Click for the map version</p></a>
+			<a href="http://map.hrtb.us/busfinder/"><p>Click for the map view</p></a>
 		</div>
 	</div>
 

--- a/index.html
+++ b/index.html
@@ -39,13 +39,20 @@
 			</div>
 		</div>
 		<div id="old-map">
-			<a href="http://map.hrtb.us/busfinder/"><p>Click for the map view</p></a>
+			<a href="http://map.hrtb.us/busfinder/"><p>Click for the map view.</p></a>
 		</div>
 	</div>
 
 	<div id="loading">
 		<img src="./img/466.gif" alt="">
 	 	<p>HRT Bus Finder is loading.</p>
+	
+		<div id="attribution">
+			<p>HRT Bus Finder was developed by volunteers from <a href="http://codeforhamptonroads.org">Code for Hampton Roads</a> in cooperation with <a href="http://gohrt.com">Hampton Roads Transit.</a></p>
+			<p>For help using this app or to answer any questions, send us an <a href="mailto:bus-tracker@codeforhamptonroads.org">email</a> or tweet <a href="https://twitter.com/oilytheotter">@oilytheotter</a> or <a href="https://twitter.com/wbprice">@wbprice</a> with hashtag #c4hrva.</p>
+			<p>We've worked hard to make the data delivered by HRT Bus Finder as accurate as possible, but we can't be held responsible for any innaccurate information.</p>
+		</div>
+
 	</div>
 
 	<div class="app-container container">

--- a/index.html
+++ b/index.html
@@ -38,6 +38,9 @@
 				</div>
 			</div>
 		</div>
+		<div id="old-map">
+			<a href="http://map.hrtb.us/busfinder/"><p>Click for the map version</p></a>
+		</div>
 	</div>
 
 	<div id="loading">
@@ -82,5 +85,12 @@
 		</div>
 		<div class="span2 timeframe quarter"><%= arriveMinutes %></div>
 	</script>
+
+	<script>
+		
+		$('#old-map').slideDown('slow').delay(5000).slideUp();
+
+	</script>
 </body>
 </html>
+


### PR DESCRIPTION
title says it all.  displays a link to map.hrtb.us/busfinder/ in header that disappears after 5 seconds.  Legal disclaimer and contact information on loading screen.
