### PR TITLE
Use single instance of Google Map object

### DIFF
--- a/css/busfinder.css
+++ b/css/busfinder.css
@@ -159,7 +159,6 @@ h1, h2, h3, h4, h5, p, a {
 
 .arrow {
 	background-color: rgba(0,0,0,.05);
-	height: :;
 }
 
 .arrow img {

--- a/index.html
+++ b/index.html
@@ -107,7 +107,7 @@
 
 		<div class="mapcanvas"></div>
 		<div class="extended-info" style="display:none;">
-			<span>Location of <strong>Bus <%= busId %></strong> as of <strong><%= lastUpdate %></strong>.</span>
+			<span>Location of <strong>Bus <%= busId %></strong> as of <strong><span class='lastUpdate'><%= lastUpdate %></span></strong>.</span>
 		</div>
 		<div class="arrow">
 			<img src="img/arrow-down.png"/>

--- a/js/busfinder.js
+++ b/js/busfinder.js
@@ -214,11 +214,11 @@ $(function(){
 		},
 		
 		showMap: function() {
-			if(this.$('.mapcanvas').is(':visible')) {
-				this.$('.extended-info').hide();
-				this.$('.mapcanvas').hide();
-				this.$('.arrow > img').attr('src', './img/arrow-down.png');
-			} else {
+			$('.extended-info').hide();
+			$('.mapcanvas').hide();
+			$('.arrow > img').attr('src', './img/arrow-down.png');
+				
+			if(!this.$('.mapcanvas').is(':visible')) {
 				var mapHeight = window.innerHeight - 220; //map height is height of screen less the height of about bar .schedule
 				App.MapView.clear();
 				App.MapView.createStopMarker(this.options.stop);

--- a/js/busfinder.js
+++ b/js/busfinder.js
@@ -130,7 +130,7 @@ $(function(){
 	
 	var MapView = Backbone.View.extend({
 		initialize: function() {
-			this.map = new google.maps.Map(this.$el[0]);
+			this.map = new google.maps.Map(this.$el[0], {disableDefaultUI: true});
 			this.markers = [];
 		},
 	    

--- a/js/busfinder.js
+++ b/js/busfinder.js
@@ -195,10 +195,11 @@ $(function(){
 		
 		updateTime: function() {
 		    this.$('.timeframe').html(this.model.minutesFromNow());
+		    this.$('.lastUpdate').html(this.model.lastCheckinTimeDescription());
 		},
 		
 		render: function() {
-		    this.mapPositions = []
+		    var mapShowing = this.$('.mapcanvas').is(':visible');
 		    
 			this.$el.html(this.template({
 				routeId: this.model.get('route_id'),
@@ -210,15 +211,21 @@ $(function(){
 				lastUpdate: this.model.lastCheckinTimeDescription()
 			}));
 			
+			if(mapShowing) {
+			    this.showMap(null);
+			}
+		    
 			return this;
 		},
 		
-		showMap: function() {
+		showMap: function(scroll) {
+		    var mapShowing = this.$('.mapcanvas').is(':visible');
+		    
 			$('.extended-info').hide();
 			$('.mapcanvas').hide();
 			$('.arrow > img').attr('src', './img/arrow-down.png');
 				
-			if(!this.$('.mapcanvas').is(':visible')) {
+			if(!mapShowing) {
 				var mapHeight = window.innerHeight - 220; //map height is height of screen less the height of about bar .schedule
 				App.MapView.clear();
 				App.MapView.createStopMarker(this.options.stop);
@@ -226,13 +233,15 @@ $(function(){
     			App.MapView.$el.height(mapHeight);
     			this.$('.mapcanvas').html(App.MapView.el);
 				
+				this.$('.arrow > img').attr('src', './img/arrow-up.png');
 			    this.$('.extended-info').show();
 				this.$('.mapcanvas').show();
 				App.MapView.resize();
 				App.MapView.setBounds();
 				
-				$('html,body').animate({scrollTop: this.$el.offset().top - 50 }, 'slow');
-				this.$('.arrow > img').attr('src', './img/arrow-up.png');
+				if(scroll) {
+				    $('html,body').animate({scrollTop: this.$el.offset().top - 50 }, 'slow');
+			    }
 			}
 		}
 	});


### PR DESCRIPTION
Previously, every arrival had it's own instance of the Map object that it instantiated before the user ever asked to see the map. Now, we instantiate a single instance at start up and show it where ever the user requests a map.
