### PR TITLE
Fix syntax error on android 2.3 and 2.2

### DIFF
--- a/js/busfinder.js
+++ b/js/busfinder.js
@@ -137,11 +137,9 @@ $(function(){
 		
 		checkForEmpty: function() {
 			if(!this.collection.length) {
-				this.$('.arrivals')
-				    .html($('<div/>', {
-						class: 'no-arrivals', 
-						text: 'No scheduled stops'
-					}));
+                var noStopsDiv = $('<div/>', {text: 'No scheduled stops'});
+                noStopsDiv.addClass('no-arrivals');
+                this.$('.arrivals').html(noStopsDiv);
 			}
 		},
 		


### PR DESCRIPTION
Android javascript engine doesn't like objects with properties named
'class'.
