### PR TITLE
added border to menu

### DIFF
--- a/css/busfinder.css
+++ b/css/busfinder.css
@@ -12,6 +12,7 @@
 #jPanelMenu-menu {
     padding-top: 50px;
     background: #EEDFCC;
+    border-left: 5px solid rgba(255, 255 , 255, 0.7);
 }
 
 #jPanelMenu-menu ul {
@@ -310,7 +311,7 @@ h1 {
 	background-color: white;
 
 }
-.onefive 
+.onefive
 {
 	width: 25%;
 	height: 48px;

--- a/js/busfinder.js
+++ b/js/busfinder.js
@@ -750,13 +750,14 @@ $(function(){
 		    return this;
 		}
 
-	})
+	});
 
 	var ContentView = Backbone.View.extend({
 		el: $(".app-container"),
 
 		initialize: function() {
-		    $('#jPanelMenu-menu').click(function() {
+
+				$('#jPanelMenu-menu').click(function() {
 		        jPM.close();
 		    });
 		},

--- a/js/jquery.jpanelmenu.js
+++ b/js/jquery.jpanelmenu.js
@@ -24,22 +24,22 @@
 					{
 						code: 27,
 						open: false,
-						close: true 
+						close: true
 					},
 					{
 						code: 37,
 						open: false,
-						close: true 
+						close: true
 					},
 					{
 						code: 39,
 						open: true,
-						close: true 
+						close: true
 					},
 					{
 						code: 77,
 						open: true,
-						close: true 
+						close: true
 					}
 				],
 
@@ -119,7 +119,7 @@
 				$(jP.panel).find('> *').each(function(){
 					if ( $(this).css('position') == 'fixed' && $(this).css(jP.options.direction) == 'auto' ) { jP.fixedChildren.push(this); }
 				});
-				
+
 				if ( jP.fixedChildren.length > 0 )
 				{
 					var newPanelStyle = { position: 'relative' };
@@ -253,7 +253,7 @@
 
 			openMenu: function(animated) {
 				if ( typeof(animated) == "undefined" || animated == null ) { animated = jP.options.animated };
-				
+
 				jP.clearTimeouts();
 
 				jP.options.before();
@@ -262,7 +262,7 @@
 				jP.setMenuState(true);
 
 				jP.setPanelStyle({ position: 'relative' });
-				
+
 				jP.showMenu();
 
 				var animationChecks = {
@@ -440,7 +440,7 @@
 				$(document).on('click',jP.panel,function(e){
 					if ( jP.menuIsOpen() ) jP.closeMenu(jP.options.animated);
 				});
-				
+
 				$(document).on('touchend',jP.panel,function(e){
 					if ( jP.menuIsOpen() ) jP.closeMenu(jP.options.animated);
 				});


### PR DESCRIPTION
I took a look at the menu panel, and figured the only way I knew how to separate it was to add a transparent white border. I also tried to make the menu interaction more consistent. Right now on the live site on my iphone, when I click the menu icon, it won't close, but animates to open. I've now targeted it to at least close when you click a link, instead of refreshing the whole page to close the panel. I'd be curious if it works with other people's tests. 
