### PR TITLE
Fix map tile issue

### DIFF
--- a/js/busfinder.js
+++ b/js/busfinder.js
@@ -479,15 +479,17 @@ $(function(){
     			this.resize(true);
     			this.$('.mapcanvas').html(App.MapView.el);
 
-				this.$('.arrow > img').attr('src', './img/arrow-up.png');
-			    this.$('.extended-info').show();
-				this.$('.mapcanvas').show();
-				App.MapView.resize();
-				App.MapView.setBounds();
+				setTimeout($.proxy(function() {
+					this.$('.arrow > img').attr('src', './img/arrow-up.png');
+					this.$('.extended-info').show();
+					this.$('.mapcanvas').show();
+					App.MapView.resize();
+					App.MapView.setBounds();
 
-				if(scroll) {
-				    $('html,body').animate({scrollTop: this.$el.offset().top - 50 }, 'slow');
-			    }
+					if(scroll) {
+						$('html,body').animate({scrollTop: this.$el.offset().top - 50 }, 'slow');
+					}
+				}, this), 250);
 			}
 		},
 


### PR DESCRIPTION
Map tiles aren't loading the first time you open the map view on any stop on the home page. Through playing around in the console, I discovered that showing the mapcanvas at different times, or even just pausing execution with a break point seems to fix the problem. I suppose it's an issue with timing of the DOM rendering. This isn't an elegant solution, but it seems to fix the issue. Open to better ideas.